### PR TITLE
Create dmg installer on Release published.

### DIFF
--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -1,8 +1,13 @@
-name: 'Release macos zip'
-on: [release]
+name: 'Release macos archives'
+on:
+  release:
+    type: [published]
 jobs:
   release:
     runs-on: macos-latest
+    env:
+      APP_NAME: PhotographicViewer
+      MACOS_APP_RELEASE_PATH: ./build/macos/Build/Products/Release
     steps:
     - uses: actions/checkout@v3
     - uses: subosito/flutter-action@v2
@@ -11,10 +16,34 @@ jobs:
         channel: 'stable'
         cache: true
         cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
-    - run: flutter build macos
-    - name: zip
-      run: zip -r PhotographicViewer.mac.zip PhotographicViewer.app
-      working-directory: ./build/macos/Build/Products/Release
+    - name: Build macOS binary
+      run: flutter build macos
+    - name: Make zip
+      run: zip -r ${{ env.APP_NAME }}.mac.zip ${{ env.APP_NAME }}.app
+      working-directory: ${{ env.MACOS_APP_RELEASE_PATH }}
+    - name: Setup create-dmg
+      run: |
+        brew update
+        brew install create-dmg
+        brew upgrade
+    - name: Create DMG Installer
+      run: |
+        create-dmg \
+          --volname ${APP_NAME} \
+          --window-pos 200 120 \
+          --window-size 800 529 \
+          --icon-size 130 \
+          --text-size 14 \
+          --icon ${APP_NAME} 260 250 \
+          --hide-extension ${APP_NAME} \
+          --app-drop-link 540 250 \
+          --hdiutil-quiet \
+          ${APP_NAME}.dmg \
+          ${APP_NAME}.app
+      working-directory: ${{ env.MACOS_APP_RELEASE_PATH }}
     - uses: softprops/action-gh-release@v1
       with:
-        files: ./build/macos/Build/Products/Release/PhotographicViewer.mac.zip
+        files: |
+          ${{ env.MACOS_APP_RELEASE_PATH }}/${{ env.APP_NAME }}.mac.zip
+          ${{ env.MACOS_APP_RELEASE_PATH }}/${{ env.APP_NAME }}.dmg
+


### PR DESCRIPTION
Release 時に macOS 用のDMG Installerを作成。

現状だと Release 時に複数回実行されてるので published に限定。

手元での実行結果はこんな感じですね。
  https://github.com/b-wind/PhotographicViewer/releases/tag/v0.1.7