### PR TITLE
bump flutter version. 3.0.5 to 3.3.1.

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.3.0'
+          flutter-version: '3.3.1'
           channel: 'stable'
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.0.5'
+          flutter-version: '3.3.0'
           channel: 'stable'
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: subosito/flutter-action@v2
       with:
-        flutter-version: '3.0.5'
+        flutter-version: '3.3.0'
         channel: 'stable'
         cache: true
         cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: subosito/flutter-action@v2
       with:
-        flutter-version: '3.3.0'
+        flutter-version: '3.3.1'
         channel: 'stable'
         cache: true
         cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -9,6 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
+            flutter-version: '3.3.0'
             channel: 'stable'
             cache: true
             cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
-            flutter-version: '3.3.0'
+            flutter-version: '3.3.1'
             channel: 'stable'
             cache: true
             cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -1,5 +1,13 @@
 name: Check source code
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  push:
+    paths-ignore:
+      - '.github/workflows'
+  pull_request:
+    paths-ignore:
+      - '.github/workflows'
+
 
 jobs:
   test:

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.0.5'
+          flutter-version: '3.3.0'
           channel: 'stable'
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.3.0'
+          flutter-version: '3.3.1'
           channel: 'stable'
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: subosito/flutter-action@v2
       with:
-        flutter-version: '3.0.5'
+        flutter-version: '3.3.0'
         channel: 'stable'
         cache: true
         cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: subosito/flutter-action@v2
       with:
-        flutter-version: '3.3.0'
+        flutter-version: '3.3.1'
         channel: 'stable'
         cache: true
         cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'

--- a/lib/my_app_bar.dart
+++ b/lib/my_app_bar.dart
@@ -98,7 +98,7 @@ class IconTextButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return TextButton(
-      style: TextButton.styleFrom(primary: color),
+      style: TextButton.styleFrom(foregroundColor: color),
       onPressed: onPressed,
       child: Row(
         mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
Github Actions で利用する Flutter SDK のバージョンアップ。

ローカル環境でも以下のコマンドを実行しておくこと推奨。

```shell
$ flutter channel stable
$ flutter upgrade
```
